### PR TITLE
feat: add option to disable querying redmine api

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,9 @@ the following options can be set via url query string:
   "markdown". default: "html". example: `https://imprint.acdh.oeaw.ac.at/21966/?format=markdown`
 - `locale: "de" | "en"`: request the imprint text in either german ("de") or english ("en").
   default: "en". example: `https://imprint.acdh.oeaw.ac.at/21966/?locale=de`
+- `redmine: "disabled" | "enabled"`: whether to query the redmine api for custom imprint
+  configuration. setting to "disabled" will return a default imprint text with `hasMatomo: true`.
+  default: "enabled". example: `https://imprint.acdh.oeaw.ac.at/21966/?redmine=disabled`
 
 ### custom text
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -55,6 +55,25 @@ describe("imprint endpoint GET /:id", () => {
 		expect(text).toMatch(/<br>/);
 	});
 
+	it("should reponse with default text when ?redmine=disabled", async () => {
+		const serviceId = 21966;
+		const req = new Request(
+			createUrl({
+				baseUrl,
+				pathname: `/${String(serviceId)}/`,
+				searchParams: createUrlSearchParams({
+					redmine: "disabled",
+				}),
+			}),
+		);
+		const res = await app.request(req);
+		const status = res.status;
+		expect(status).toBe(200);
+		const text = await res.text();
+		expect(text).toMatch(/<h2>Legal disclosure/i);
+		expect(text).toMatch(/<br>/);
+	});
+
 	it("should respond with markdown when ?format=markdown query param is set", async () => {
 		const serviceId = 21966;
 		const req = new Request(

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ const searchParamsSchema = v.object({
 		),
 		"en",
 	),
+	redmine: v.optional(v.picklist(["disabled", "enabled"]), "enabled"),
 });
 
 app.get(
@@ -50,10 +51,12 @@ app.get(
 	validator("query", searchParamsSchema),
 	async (c) => {
 		const { id: serviceId } = c.req.valid("param");
-		const { format, locale } = c.req.valid("query");
+		const { format, locale, redmine } = c.req.valid("query");
 
-		const issue = await getRedmineIssueById(serviceId);
-		const config = getImprintConfig(issue);
+		const config =
+			redmine !== "disabled"
+				? getImprintConfig(await getRedmineIssueById(serviceId))
+				: { hasMatomo: true };
 		const { template, partials } = getTemplate(locale, config);
 		const markdown = templite(template, partials);
 


### PR DESCRIPTION
this adds a new query param to disable querying the redmine api for custom imprint configuration (which can be set there in a custom yaml 1.1 field).

this is mostly useful for non-production deployments, which don't care about correct imprint texts, and want to eliminate the brittle redmine api, which often causes ci/cd failures.